### PR TITLE
Update Labtech.psm1 - POSH Version Checking

### DIFF
--- a/LabTech.psm1
+++ b/LabTech.psm1
@@ -19,6 +19,8 @@
 #>
 
 #requires -version 3
+if (-not ($PSVersionTable)) {Write-Output 'PS1 Detected. PowerShell Version 2.0 or higher is required.';return}
+if (-not ($PSVersionTable) -or $PSVersionTable.PSVersion.Major -lt 3 ) {Write-Verbose 'PS2 Detected. PowerShell Version 3.0 or higher may be required for full functionality';return}
 
 #Module Version
 $ModuleVersion = "1.0"


### PR DESCRIPTION
POSH 1.0 will abort loading with a message. POSH 2.0 will have a warning in verbose mode. POSH 3.0 and above will process without interruption.